### PR TITLE
Asset security

### DIFF
--- a/source/create/avatars/create-avatars.rst
+++ b/source/create/avatars/create-avatars.rst
@@ -14,7 +14,7 @@ There are three ways to get your own avatar. You can either:
 
 .. note:: If you get an avatar from an external source such as TurboSquid, CGTrader, MakeHuman, or VRoid Studio, it is likely that the skeleton does not match our :doc:`avatar standards <avatar-standards>`. To use these avatars with Overte, use the `Overte Avatar Exporter for Unity <find-avatars.html#overte-avatar-exporter-for-unity>`_ to correctly map the skeleton and package your avatar.
 
-If you want to create an avatar from scratch, this page covers the steps needed to create, rig, and package your avatar. Learn more about the `security of your assets <../../security/asset-security.html>`_.
+If you want to create an avatar from scratch, this page covers the steps needed to create, rig, and package your avatar. Learn more about the :doc:`security of your assets <../../security/asset-security>`.
 
 .. contents:: On This Page
     :depth: 2

--- a/source/create/avatars/find-avatars.rst
+++ b/source/create/avatars/find-avatars.rst
@@ -6,7 +6,8 @@
 Find and Use an Existing Avatar
 ###############################
 
-You can download avatars for use from external sources such as TurboSquid or CGTrader. Once you get the avatar, you will need to process it in Unity using the Overte Avatar Exporter. This tool imports most avatars into Unity, maps their skeleton using Unity's humanoid tool, and exports them as FST and FBX files to import in-world. Learn more about the `security of your assets <../../security/asset-security.html>`_.
+You can download avatars for use from external sources such as TurboSquid or CGTrader. Once you get the avatar, you will need to process it in Unity using the Overte Avatar Exporter. This tool imports most avatars into Unity, maps their skeleton using Unity's humanoid tool, and exports them as FST and FBX files to import in-world.
+Learn more about the :doc:`security of your assets <../../security/asset-security>`.
 
 .. contents:: On This Page
     :depth: 3

--- a/source/host/add-content/create-content.rst
+++ b/source/host/add-content/create-content.rst
@@ -6,7 +6,8 @@
 Build and Add Your Own Content
 ##############################
 
-Maybe you've wandered around the metaverse, and you're inspired by the creativity of others. Or maybe none of the other domains really fit the atmosphere of what you have in mind. Whatever the reason, you're ready to branch out and build content of your own. If you don't know where to begin, this is a great place to start. Learn more about the `security of your assets <../../security/asset-security.html>`_.
+Maybe you've wandered around the metaverse, and you're inspired by the creativity of others. Or maybe none of the other domains really fit the atmosphere of what you have in mind. Whatever the reason, you're ready to branch out and build content of your own. If you don't know where to begin, this is a great place to start.
+Learn more about the :doc:`security of your assets <../../security/asset-security>`.
 
 .. contents:: On This Page
     :depth: 2

--- a/source/host/configure-settings/permission-settings.rst
+++ b/source/host/configure-settings/permission-settings.rst
@@ -108,7 +108,7 @@ The actions that you can secure for each type of user are as follows:
 |                         | <https://apidocs.overte.org/Entities.html#.EntityProperties>`_ type          |
 |                         | definition.                                                                  |
 +-------------------------+------------------------------------------------------------------------------+
-| Can View Asset URLs     | Sets whether a user can view asset URLS in **Create** and scripts. If a user |
+| Can View Asset URLs     | Sets whether a user can view asset URLs in **Create** and scripts. If a user |
 |                         | doesn't have this permission, the URLs will be reported as empty strings.    |
 |                         | Note: this is only a client-side protection. Learn more about                |
 |                         | :doc:`asset security <../../security/asset-security>`.                       |

--- a/source/host/configure-settings/permission-settings.rst
+++ b/source/host/configure-settings/permission-settings.rst
@@ -111,5 +111,5 @@ The actions that you can secure for each type of user are as follows:
 | Can View Asset URLs     | Sets whether a user can view asset URLS in **Create** and scripts. If a user |
 |                         | doesn't have this permission, the URLs will be reported as empty strings.    |
 |                         | Note: this is only a client-side protection. Learn more about                |
-|                         | `asset security <../../security/asset-security.html>`_.                      |
+|                         | :doc:`asset security <../../security/asset-security>`.                       |
 +-------------------------+------------------------------------------------------------------------------+

--- a/source/security/asset-security.rst
+++ b/source/security/asset-security.rst
@@ -2,11 +2,11 @@
 Asset Security
 ###############################
 
-Like a web browser, Overte allows you to bring together assets like models and images from external sources and share them with others. This allows you to create diverse domains and assume unique avatars using simple URLs. When you connect to a domain, your client will download and display entities and avatars using those links, just as a web browser loads an image.
+Like a web browser, Overte allows you to bring together assets like models and images from external sources and share them with others. This allows you to create diverse domains and wear unique avatars using simple URLs. When you connect to a domain, your client will download and display entities and avatars using those links, just as a web browser loads an image.
 
-However, it is not always desirable to allow others to trivially copy your content or avatars by URL. We encourage collaborative building and sharing of assets pursuant to their licenses, but we understand that content creators may want to keep their assets private and that avatars are often personal representations that are not meant to be copied.
+However, it is not always desirable to allow others to trivially copy your content or avatars by URL. We encourage collaborative building and sharing of assets following their licenses, but we understand that content creators may want to keep their assets private and that avatars are often personal representations that are not meant to be copied.
 
-Since Overte is open source, it is difficult to solve this problem completely. Bad actors will always be able to modify their clients or rip assets directly from the GPU. We can only aim to make it more difficult for them. We have outlined some of the tools we offer below and are always open to more suggestions and especially PRs.
+Since Overte is open source, it is difficult to solve this problem completely. Bad actors will always be able to modify their clients or rip assets directly from memory. We can only aim to make it more difficult for them. We have outlined some of the tools we offer below and are always open to more suggestions and especially PRs.
 
 .. contents:: On This Page
     :depth: 2
@@ -19,7 +19,7 @@ Multiple types of Entities refer to external assets such as models, images, shad
 
 However, even if a user doesn't have Rez permission and can't access Create, the URLs can still be accessed via scripts. You can prevent scripts from accessing these URLs by revoking a user's **Can View Asset URLs** permission.
 
-These protections are **client-side only**. This means that a malicious person with a modified client could circumvent them. There are two other options you can use to alleviate this concern:
+These protections are **client-side only**. This means that a malicious person with a modified client could circumvent them. There are two other methods for protecting your assets:
 
 * For models and images, bake your assets using the :doc:`Oven <../host/add-content/bake-content>`. As a side effect of compressing and optimizing them, the Oven makes it harder (**but not impossible**) to open these files in other programs.
 * Use the **Asset Server**. If you upload content to the asset server, it will provide you an `atp` link which only works within your domain.
@@ -46,9 +46,9 @@ Have the Domain Server Obfuscate URLs
 
 Instead of sending URLs, the Domain Server could itself download the assets and send data directly to clients.
 
-For avatars, while this would prevent trivial copying of URLs, it opens domain operators up to legal repurcussions for serving copyrighted or illegal content.
+For avatars, while this would prevent trivial copying of URLs, it opens domain operators up to legal consequences for serving copyrighted or illegal content.
 
-For entities, this is effectively what the Asset Server already does, if you choose to use it. It is important to carefully control who has Rez permission in your domain to avoid the above legal ramifications.
+For entities, this is effectively what the Asset Server already does, if you choose to use it. It is important to carefully control who has Rez permission in your domain to avoid the above legal trouble.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Peer-to-Peer Avatar Sharing
@@ -56,7 +56,7 @@ Peer-to-Peer Avatar Sharing
 
 Users could share their avatars via a peer-to-peer network, either via the Domain Server or directly with other clients.
 
-Like the above, this opens others up to legal ramifications for sharing copyrighted or illegal content. Additionally, peer-to-peer traffic can lead to legal ramifications for people in many countries and institutions (e.g. schools) even if the content itself is not illegal.
+Like the above, this opens others up to legal trouble for sharing copyrighted or illegal content. Additionally, peer-to-peer traffic can lead to legal consequences for people in many countries and institutions (e.g. schools) even if the content itself is not illegal.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Server-side Avatar Verification
@@ -74,4 +74,4 @@ In an FST, you could optionally specify permissions for who is allowed to view y
 
 This would allow you to show your true avatar only to trusted friends. The Avatar Mixer would check the permissions for each connection before sending the URLs.
 
-Although there are technical questions about how this would work with differently-rigged or differently-sized avatars for the fallback, and it can be jarring to have others not be able to see your true avatar, this would be a nice option to have for those who want it.
+Although there are technical questions about how this would work with differently-rigged or differently-sized avatars for the fallback, and it can be confusing to have others not be able to see your true avatar, this would be a nice option to have for those who want it.

--- a/source/security/asset-security.rst
+++ b/source/security/asset-security.rst
@@ -15,13 +15,13 @@ Since Overte is open source, it is difficult to solve this problem completely. B
 Entities
 ----------------------
 
-Multiple types of Entities refer to external assets such as models, images, shaders, sounds, etc. These URLs are most commonly accessed via the **Create** app. You can prevent a visitor to your domain from using Create by revoking their **Rez** and **Rez Temporary** `permissions <../host/configure-settings/permission-settings.html>`_.
+Multiple types of Entities refer to external assets such as models, images, shaders, sounds, etc. These URLs are most commonly accessed via the **Create** app. You can prevent a visitor to your domain from using Create by revoking their **Rez** and **Rez Temporary** :doc:`permissions <../host/configure-settings/permission-settings>`.
 
 However, even if a user doesn't have Rez permission and can't access Create, the URLs can still be accessed via scripts. You can prevent scripts from accessing these URLs by revoking a user's **Can View Asset URLs** permission.
 
 These protections are **client-side only**. This means that a malicious person with a modified client could circumvent them. There are two other options you can use to alleviate this concern:
 
-* For models and images, bake your assets using the `Oven <../host/add-content/bake-content.html>`_. As a side effect of compressing and optimizing them, the Oven makes it harder (**but not impossible**) to open these files in other programs.
+* For models and images, bake your assets using the :doc:`Oven <../host/add-content/bake-content>`. As a side effect of compressing and optimizing them, the Oven makes it harder (**but not impossible**) to open these files in other programs.
 * Use the **Asset Server**. If you upload content to the asset server, it will provide you an `atp` link which only works within your domain.
 
 ----------------------------------

--- a/source/security/asset-security.rst
+++ b/source/security/asset-security.rst
@@ -75,3 +75,7 @@ In an FST, you could optionally specify permissions for who is allowed to view y
 This would allow you to show your true avatar only to trusted friends. The Avatar Mixer would check the permissions for each connection before sending the URLs.
 
 Although there are technical questions about how this would work with differently-rigged or differently-sized avatars for the fallback, and it can be confusing to have others not be able to see your true avatar, this would be a nice option to have for those who want it.
+
+**See Also**
+
++ :doc:`How to contribute </contribute>`


### PR DESCRIPTION
Changed the link format, so that Sphinx can throw warnings on invalid links.

Simplified the language. The English documentation is used by a very international audience and often read by people who aren't particularly good at it.

Miscellaneous changes.